### PR TITLE
O40-1004 Added Transaction Inputs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        - GPR_TOKEN
     volumes:
       - ./src:/app/src:delegated
       - ./output:/app/output:delegated

--- a/src/queues/generateProof.mjs
+++ b/src/queues/generateProof.mjs
@@ -12,6 +12,7 @@ export default function receiveMessage() {
     const {
       folderpath,
       inputs,
+      transactionInputs,
       outputDirectoryPath,
       proofFileName,
       backend = 'zexe',
@@ -56,7 +57,7 @@ export default function receiveMessage() {
       logger.debug(proof);
       logger.debug(publicInputs);
 
-      response.data = { proof, inputs: publicInputs };
+      response.data = { proof, inputs: publicInputs, transactionInputs };
     } catch (err) {
       response.error = err;
     }

--- a/src/routes/generateProof.mjs
+++ b/src/routes/generateProof.mjs
@@ -13,6 +13,7 @@ router.post('/', async (req, res, next) => {
   const {
     folderpath,
     inputs,
+    transactionInputs,
     outputDirectoryPath,
     proofFileName,
     backend = 'zexe',
@@ -57,6 +58,7 @@ router.post('/', async (req, res, next) => {
       proof,
       inputs: publicInputs,
       type: folderpath,
+      transactionInputs,
     });
   } catch (err) {
     return next(err);

--- a/test/http.mjs
+++ b/test/http.mjs
@@ -77,12 +77,14 @@ describe('Testing the http API', () => {
       .send({
         folderpath: 'factor',
         inputs: [6, 3, 2],
+        transactionInputs: 'test',
         provingScheme: 'gm17',
         backend: 'libsnark',
       })
       .end((err, res) => {
         expect(res.body).to.have.property('proof');
         expect(res.body).to.have.property('type');
+        expect(res.body).to.have.property('transactionInputs');
         expect(res.body.proof).to.have.property('a');
         expect(res.body.proof).to.have.property('b');
         expect(res.body.proof).to.have.property('c');

--- a/test/queue.mjs
+++ b/test/queue.mjs
@@ -105,6 +105,7 @@ describe('Testing the Zokrates queue mechanism', () => {
       {
         folderpath: 'factor',
         inputs: [6, 3, 2],
+        transactionInputs: 'test',
         provingScheme: 'gm17',
         backend: 'libsnark',
       },
@@ -118,11 +119,13 @@ describe('Testing the Zokrates queue mechanism', () => {
       expect(response).to.have.property('type');
       expect(response).to.have.property('data');
       expect(response.data).to.have.property('proof');
+      expect(response.data).to.have.property('transactionInputs');
       expect(response.data.proof).to.have.property('a');
       expect(response.data.proof).to.have.property('b');
       expect(response.data.proof).to.have.property('c');
       expect(response.data.proof.a).to.be.instanceof(Array);
       expect(response.type).to.equal('factor');
+      expect(response.data.transactionInputs).to.equal('test');
       done();
     });
   });


### PR DESCRIPTION
### Related Ticket

https://eyblockchain.atlassian.net/browse/O40-1004

### Description

Added transaction inputs to be passed from nightfall-sdk and passed back.  Fixed docker file which was erroring on `docker-compose up -d`

### QA Instructions

ensure unit tests pass. 

### Checklist

- [x] I have reviewed the code changes myself
- [x] My code meets all of the acceptance criteria of the ticket it closes.
- [x] I have removed unused code (e.g., `console.logs`, commented out blocks, etc.)
- [ ] I have made all necessary changes to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] Any dependent changes have been merged and published.
