### PR TITLE
feat: update zokrates to --allow-unconstrained-variables flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG GPR_TOKEN
 
-FROM zokrates/zokrates:0.6.3 as builder
+FROM zokrates/zokrates:0.6.4 as builder
 
 FROM node:14.11.0 as node-build
 ARG GPR_TOKEN

--- a/package-lock.json
+++ b/package-lock.json
@@ -1427,9 +1427,9 @@
       }
     },
     "@eyblockchain/zokrates-zexe.js": {
-      "version": "0.2.1",
-      "resolved": "https://npm.pkg.github.com/download/@eyblockchain/zokrates-zexe.js/0.2.1/8a788db96836f9b6f2044b4492db5b847e4c04dee8f32ef9a57369d0146e9694",
-      "integrity": "sha1-yDexYB3fCDypb/pHEvNU3pgtDX4=",
+      "version": "0.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@eyblockchain/zokrates-zexe.js/0.3.0/e0fb977d25624efc543d290a16b326ce0cf56c38ab7c5772734c2208d937fa68",
+      "integrity": "sha512-eUwsJRCZxlBul1oZOsh/qVilCffhDNqhaQlBiwqvkdSrS2mMgYYay/gO8ASMFx6p7dXfqsO3JP+YVfIJbIX5WQ==",
       "requires": {
         "jsonfile": "^6.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     }
   },
   "dependencies": {
-    "@eyblockchain/zokrates-zexe.js": "^0.2.1",
+    "@eyblockchain/zokrates-zexe.js": "^0.3.0",
     "@semantic-release/git": "^9.0.0",
     "amqplib": "^0.6.0",
     "body-parser": "1.19.0",


### PR DESCRIPTION

### Description

<!-- Brief description of the code changes. Add supporting screenshots & videos where applicable. -->

This PR bumps ZoKrates to 0.6.4 which enables the `--allow-unconstrained-variables` flag.  This flag is jolly handy if you have a complex proof that you want to stub out to speed up testing.  Usually a stub has unconstrained variables and the compile will disallow these.  It's painful to fix that and nugatory if it's just a stub.

### QA Instructions

<!-- How others should test your changes and check for any possible regressions. -->

To test use `docker-compose up --build` to run up the container, then run `npm t` in a separate terminal.

### Checklist

<!-- Go over the checklist, and put an `x` in all the boxes when you confirm they've been done. -->

- [x ] I have reviewed the code changes myself
- [x ] My code meets all of the acceptance criteria of the ticket it closes.
- [x ] I have removed unused code (e.g., `console.logs`, commented out blocks, etc.)
- [x ] I have made all necessary changes to the documentation.
- [x ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
- [x ] Any dependent changes have been merged and published.
