### PR TITLE
fix: aquasec vulnerabilities

### DIFF
--- a/.github/workflows/release-updated.yml
+++ b/.github/workflows/release-updated.yml
@@ -38,9 +38,9 @@ jobs:
       #          GPR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker push version
         run: |
-          docker build --no-cache --build-arg GPR_TOKEN=$GPR_TOKEN -t ghcr.io/eyblockchain/zokrates-worker-updated:v0.7.0 .
-          docker tag ghcr.io/eyblockchain/zokrates-worker-updated:v0.7.0 ghcr.io/eyblockchain/zokrates-worker-updated:latest
-          docker push ghcr.io/eyblockchain/zokrates-worker-updated:v0.7.0
+          docker build --no-cache --build-arg GPR_TOKEN=$GPR_TOKEN -t ghcr.io/eyblockchain/zokrates-worker-updated:v0.8.0 .
+          docker tag ghcr.io/eyblockchain/zokrates-worker-updated:v0.8.0 ghcr.io/eyblockchain/zokrates-worker-updated:latest
+          docker push ghcr.io/eyblockchain/zokrates-worker-updated:v0.8.0
           docker push ghcr.io/eyblockchain/zokrates-worker-updated:latest
         env:
           GPR_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build zokrates from source for local verify
-FROM rust:1.53.0 as builder
+FROM rust:1.53.0 AS builder
 WORKDIR /app
 COPY . .
 RUN git clone --depth 1 --branch 0.8.8 https://github.com/Zokrates/ZoKrates /app/zoKratesv0.8.8
@@ -14,6 +14,7 @@ ENV USERNAME="node"
 WORKDIR /app
 # Install Node.js with cleanup and optimization
 RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends && \
     apt-get install -y --no-install-recommends \
         netcat-traditional \
         curl \

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.22.1",
         "express-fileupload": "^1.4.0",
         "jsonfile": "^6.1.0",
-        "tar": "^7.5.9",
+        "tar": "^7.5.11",
         "web3": "^4.2.1",
         "winston": "^3.3.3"
       },
@@ -1304,9 +1304,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -2524,9 +2524,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/pathval": {
@@ -3112,9 +3112,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
-      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "express": "^4.22.1",
     "express-fileupload": "^1.4.0",
     "jsonfile": "^6.1.0",
-    "tar": "^7.5.9",
+    "tar": "^7.5.11",
     "web3": "^4.2.1",
     "winston": "^3.3.3"
   },
@@ -31,7 +31,9 @@
     "nodemon": "^3.0.1"
   },
   "overrides": {
-    "glob": "11.1.0"
+    "glob": "11.1.0",
+    "follow-redirects": "1.16.0",
+    "path-to-regexp": "0.1.13"
   },
   "nodemonConfig": {
     "verbose": true,


### PR DESCRIPTION
### Related Ticket
https://eyblockchain.atlassian.net/browse/API2-1155

### Description
Fix Aquasec vulnerabilities.
1. Upgrade OSS versions:
    `tar` to "^7.5.11`
    `glob" to `11.1.0`
    `follow-redirects to `1.16.0`
    `path-to-regexp` to `0.1.13`
2. Base image apk upgrades to fix vulnerabilities if any cause out of it
3. Update release version to `zokrates-worker-updated:v0.8.0`


### QA Instructions

<!-- How others should test your changes and check for any possible regressions. -->

- [ ] Step 1

### Checklist

<!-- Go over the checklist, and put an `x` in all the boxes when you confirm they've been done. -->

- [ ] I have reviewed the code changes myself
- [ ] My code meets all of the acceptance criteria of the ticket it closes.
- [ ] I have removed unused code (e.g., `console.logs`, commented out blocks, etc.)
- [ ] I have made all necessary changes to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Any dependent changes have been merged and published.
